### PR TITLE
Consistent data for inApp deep link handler

### DIFF
--- a/plugins/src/android/OptimoveSDKPlugin.java
+++ b/plugins/src/android/OptimoveSDKPlugin.java
@@ -452,7 +452,7 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
                 inAppButtonPress.put("messageId", buttonPress.getMessageId());
                 inAppButtonPress.put("messageData", buttonPress.getMessageData());
             } catch (JSONException e) {
-                LOG.e("inAppDeepLinkHandler handling failed due to JSONException. error message:", e.getMessage());
+                //noop
                 return;
             }
             sendMessageToJs("inAppDeepLink", inAppButtonPress);

--- a/plugins/src/android/OptimoveSDKPlugin.java
+++ b/plugins/src/android/OptimoveSDKPlugin.java
@@ -452,7 +452,6 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
                 inAppButtonPress.put("messageData", buttonPress.getMessageData());
             } catch (JSONException e) {
                 //noop
-                return;
             }
             sendMessageToJs("inAppDeepLink", inAppButtonPress);
         }

--- a/plugins/src/android/OptimoveSDKPlugin.java
+++ b/plugins/src/android/OptimoveSDKPlugin.java
@@ -452,7 +452,7 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
                 inAppButtonPress.put("messageId", buttonPress.getMessageId());
                 inAppButtonPress.put("messageData", buttonPress.getMessageData());
             } catch (JSONException e) {
-                LOG.e("inAppDeepLinkHandler failed due to JSONException. error message:", e.getMessage());
+                LOG.e("inAppDeepLinkHandler handling failed due to JSONException. error message:", e.getMessage());
                 return;
             }
             sendMessageToJs("inAppDeepLink", inAppButtonPress);

--- a/plugins/src/android/OptimoveSDKPlugin.java
+++ b/plugins/src/android/OptimoveSDKPlugin.java
@@ -20,6 +20,7 @@ import com.optimove.android.optimobile.PushMessage;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -445,7 +446,16 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
 
         @Override
         public void handle(Context context, InAppButtonPress buttonPress) {
-            sendMessageToJs("inAppDeepLink", buttonPress.getDeepLinkData());
+            JSONObject inAppButtonPress = new JSONObject();
+            try {
+                inAppButtonPress.put("deepLinkData", buttonPress.getDeepLinkData());
+                inAppButtonPress.put("messageId", buttonPress.getMessageId());
+                inAppButtonPress.put("messageData", buttonPress.getMessageData());
+            } catch (JSONException e) {
+                LOG.e("inAppDeepLinkHandler failed due to JSONException. error message:", e.getMessage());
+                return;
+            }
+            sendMessageToJs("inAppDeepLink", inAppButtonPress);
         }
     }
 

--- a/plugins/src/android/OptimoveSDKPlugin.java
+++ b/plugins/src/android/OptimoveSDKPlugin.java
@@ -20,7 +20,6 @@ import com.optimove.android.optimobile.PushMessage;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
-import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;


### PR DESCRIPTION
different data passed to inApp deep link handler on different platforms. On ios we pass deep link data, message data and message id. On android only deep link data. Consistently pass all InAppButtonPressed object’s field to js