### PR TITLE
Add DDL support on iOS

### DIFF
--- a/ExampleApp/www/js/index.js
+++ b/ExampleApp/www/js/index.js
@@ -212,9 +212,14 @@ document
   .addEventListener("click", inAppMarkAsRead);
 
 function getInboxItemForTesting() {
-  var id = document.getElementById("text-area-in-app-inbox-item").value;
+  var id = parseInt(document.getElementById("text-area-in-app-inbox-item").value);
+  if (isNaN(id)){
+    alert("item id is required");
+    return;
+  }
+
   var item = {
-    id: parseInt(id),
+    id: id,
   };
 
   return item;

--- a/plugins/src/android/OptimoveInitProvider.java
+++ b/plugins/src/android/OptimoveInitProvider.java
@@ -111,39 +111,47 @@ public class OptimoveInitProvider extends ContentProvider {
         return (Context context, DeferredDeepLinkHelper.DeepLinkResolution resolution, String link,
                 @Nullable DeferredDeepLinkHelper.DeepLink data) -> {
             try {
-                String mappedResolution = null;
-                JSONObject dataJson = null;
+                String mappedResolution;
+                String url;
+                JSONObject deepLinkContent = null;
+                JSONObject linkData = null;
+
                 switch (resolution) {
                     case LINK_MATCHED:
                         mappedResolution = "LINK_MATCHED";
-                        JSONObject deepLinkContent = new JSONObject();
+                        url = data.url;
+
+                        deepLinkContent = new JSONObject();
                         deepLinkContent.put("title", data.content.title);
                         deepLinkContent.put("description", data.content.description);
 
-                        dataJson = new JSONObject();
-                        dataJson.put("data", data.data);
-                        dataJson.put("content", deepLinkContent);
-                        dataJson.put("url", data.url);
+                        linkData = data.data;
+
                         break;
                     case LINK_NOT_FOUND:
                         mappedResolution = "LINK_NOT_FOUND";
+                        url = link;
                         break;
                     case LINK_EXPIRED:
                         mappedResolution = "LINK_EXPIRED";
+                        url = link;
                         break;
                     case LINK_LIMIT_EXCEEDED:
                         mappedResolution = "LINK_LIMIT_EXCEEDED";
+                        url = link;
                         break;
                     case LOOKUP_FAILED:
                     default:
                         mappedResolution = "LOOKUP_FAILED";
+                        url = link;
                         break;
                 }
 
                 JSONObject deepLink = new JSONObject();
-                deepLink.put("link", link);
                 deepLink.put("resolution", mappedResolution);
-                deepLink.put("data", dataJson);
+                deepLink.put("url", url);
+                deepLink.put("content", deepLinkContent == null ? JSONObject.NULL : deepLinkContent);
+                deepLink.put("linkData", linkData == null ? JSONObject.NULL : linkData);
 
                 if (OptimoveSDKPlugin.jsCallbackContext == null) {
                     OptimoveSDKPlugin.pendingDDL = deepLink;

--- a/plugins/src/android/OptimoveSDKPlugin.java
+++ b/plugins/src/android/OptimoveSDKPlugin.java
@@ -336,9 +336,9 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
         }
     }
 
-    static boolean sendMessageToJs(String type, JSONObject data) {
+    static void sendMessageToJs(String type, JSONObject data) {
         if (null == jsCallbackContext) {
-            return false;
+            return;
         }
 
         JSONObject message = new JSONObject();
@@ -347,14 +347,12 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
             message.put("data", data);
         } catch (JSONException e) {
             e.printStackTrace();
-            return false;
+            return;
         }
 
         PluginResult result = new PluginResult(PluginResult.Status.OK, message);
         result.setKeepCallback(true);
         jsCallbackContext.sendPluginResult(result);
-
-        return true;
     }
 
     private void pushRegister(CallbackContext callbackContext) {
@@ -400,25 +398,27 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
                 Date availableFrom = item.getAvailableFrom();
                 Date availableTo = item.getAvailableTo();
                 Date dismissedAt = item.getDismissedAt();
-                mapped.put("data", item.getData());
+
+                JSONObject data = item.getData();
+                mapped.put("data", data == null ? JSONObject.NULL : data);
 
                 URL imageUrl = item.getImageUrl();
-                mapped.put("imageUrl", imageUrl == null ? null : imageUrl.toString());
+                mapped.put("imageUrl", imageUrl == null ? JSONObject.NULL : imageUrl.toString());
 
                 if (null == availableFrom) {
-                    mapped.put("availableFrom", null);
+                    mapped.put("availableFrom", JSONObject.NULL);
                 } else {
                     mapped.put("availableFrom", formatter.format(availableFrom));
                 }
 
                 if (null == availableTo) {
-                    mapped.put("availableTo", null);
+                    mapped.put("availableTo", JSONObject.NULL);
                 } else {
                     mapped.put("availableTo", formatter.format(availableTo));
                 }
 
                 if (null == dismissedAt) {
-                    mapped.put("dismissedAt", null);
+                    mapped.put("dismissedAt", JSONObject.NULL);
                 } else {
                     mapped.put("dismissedAt", formatter.format(dismissedAt));
                 }
@@ -464,7 +464,8 @@ public class OptimoveSDKPlugin extends CordovaPlugin {
             try {
                 inAppButtonPress.put("deepLinkData", buttonPress.getDeepLinkData());
                 inAppButtonPress.put("messageId", buttonPress.getMessageId());
-                inAppButtonPress.put("messageData", buttonPress.getMessageData());
+                JSONObject messageData = buttonPress.getMessageData();
+                inAppButtonPress.put("messageData", messageData == null ? JSONObject.NULL : messageData);
             } catch (JSONException e) {
                 // noop
             }

--- a/plugins/src/android/PushReceiver.java
+++ b/plugins/src/android/PushReceiver.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.core.app.TaskStackBuilder;
 
 import com.optimove.android.Optimove;
@@ -24,27 +26,25 @@ public class PushReceiver extends PushBroadcastReceiver {
     }
 
     static JSONObject pushMessageToJsonObject(PushMessage pushMessage, String actionId) {
-        JSONObject message = new JSONObject();
+        JSONObject result = new JSONObject();
 
+        String title = pushMessage.getTitle();
+        String message = pushMessage.getMessage();
+        Uri uri = pushMessage.getUrl();
+        JSONObject data = pushMessage.getData();
         try {
-            message.put("id", pushMessage.getId());
-            message.put("title", pushMessage.getTitle());
-            message.put("message", pushMessage.getMessage());
+            result.put("id", pushMessage.getId());
+            result.put("title", title == null ? JSONObject.NULL : title);
+            result.put("message", message == null ? JSONObject.NULL : message);
+            result.put("url", uri == null ? JSONObject.NULL : uri.toString());
+            result.put("actionId", actionId == null ? JSONObject.NULL : actionId);
+            result.put("data", data == null ? JSONObject.NULL : data);
 
-            if (null != pushMessage.getUrl()) {
-                message.put("url", pushMessage.getUrl().toString());
-            }
-
-            if (actionId != null) {
-                message.put("actionId", actionId);
-            }
-
-            message.put("data", pushMessage.getData());
         } catch (JSONException e) {
             e.printStackTrace();
         }
 
-        return message;
+        return result;
     }
 
     @Override

--- a/plugins/src/core/ddl.ts
+++ b/plugins/src/core/ddl.ts
@@ -1,17 +1,13 @@
 export interface DeepLinkContent {
-  title?: string;
-  description?: string;
-}
-export interface DeepLinkData {
-  data: Record<string,any>;
-  content: DeepLinkContent;
-  url: string;
+  title: string | null;
+  description: string | null;
 }
 
 export interface DeepLink {
-  link: string;
   resolution: DeepLinkResolution;
-  data: DeepLinkData;
+  url: string;
+  content: DeepLinkContent | null;
+  linkData: Record<string,any> | null;
 }
 
 export enum DeepLinkResolution {

--- a/plugins/src/core/declarations/ddl.d.ts
+++ b/plugins/src/core/declarations/ddl.d.ts
@@ -1,16 +1,12 @@
 export interface DeepLinkContent {
-    title?: string;
-    description?: string;
-}
-export interface DeepLinkData {
-    data: Record<string, any>;
-    content: DeepLinkContent;
-    url: string;
+    title: string | null;
+    description: string | null;
 }
 export interface DeepLink {
-    link: string;
     resolution: DeepLinkResolution;
-    data: DeepLinkData;
+    url: string;
+    content: DeepLinkContent | null;
+    linkData: Record<string, any> | null;
 }
 export declare enum DeepLinkResolution {
     LOOKUP_FAILED = "LOOKUP_FAILED",

--- a/plugins/src/core/declarations/push.d.ts
+++ b/plugins/src/core/declarations/push.d.ts
@@ -4,4 +4,5 @@ export interface PushNotification {
     message: string | null;
     data: Record<string, any> | null;
     url: string | null;
+    actionId: string | null;
 }

--- a/plugins/src/core/push.ts
+++ b/plugins/src/core/push.ts
@@ -4,4 +4,5 @@ export interface PushNotification {
   message: string | null;
   data: Record<string,any> | null;
   url: string | null;
+  actionId: string | null;
 }

--- a/plugins/src/ios/Bridging-Header.h
+++ b/plugins/src/ios/Bridging-Header.h
@@ -3,4 +3,17 @@
 //copied from ProductModuleName-Swift.h
 @interface Optimove_Cordova
 + (void)didFinishLaunching:(NSNotification * _Nonnull)notification;
+
+
++ (BOOL)application:(UIApplication * _Nonnull)application
+userActivity:(NSUserActivity * _Nonnull)userActivity
+restorationHandler:(void (^_Nonnull)(NSArray<id<UIUserActivityRestoring>> * _Nonnull restorableObjects))restorationHandler;
+
++ (void)scene:(UIScene * _Nonnull)scene
+session:(UISceneSession * _Nonnull)session
+options:(UISceneConnectionOptions * _Nonnull)connectionOptions API_AVAILABLE(ios(13.0));
+
++ (void)scene:(UIScene * _Nonnull)scene
+userActivity:(NSUserActivity * _Nonnull)userActivity API_AVAILABLE(ios(13.0));
+
 @end

--- a/plugins/src/ios/OptimoveSDKPlugin.swift
+++ b/plugins/src/ios/OptimoveSDKPlugin.swift
@@ -531,9 +531,31 @@ enum InAppConsentStrategy: String {
 
         return [
             "resolution": resolution,
-            "urlString": urlString,
+            "url": urlString,
             "content": content,
             "linkData": linkData,
         ]
+    }
+
+    @objc(application:userActivity:restorationHandler:)
+    static func application(_ application: UIApplication, userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void){
+        _ = Optimove.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    }
+
+    @available(iOS 13.0, *)
+    @objc(scene:session:options:)
+    static func scene(_ scene: UIScene, session: UISceneSession, options: UIScene.ConnectionOptions) {
+        guard let _ = (scene as? UIWindowScene) else { return }
+
+        // Deep links from cold starts
+        if let userActivity = options.userActivities.first {
+            Optimove.shared.scene(scene, continue: userActivity)
+        }
+    }
+
+    @available(iOS 13.0, *)
+    @objc(scene:userActivity:)
+    static func scene(_ scene: UIScene, userActivity: NSUserActivity) {
+        Optimove.shared.scene(scene, continue: userActivity)
     }
 }


### PR DESCRIPTION
1. Set up deferred deep link handler in Swift. Consumers need to update their AppDelegate or SceneDelegate like in other SDKs
2. Align shape of deep link returned to js with Flutter SDK. Update Android to have same shape.
3. Return nulls from android. `JSONObject.put("key", null)` does not actually add null. To match ts interfaces replace with `JSONObject.put("key", JSONObject.NULL)`
4. minor tweak to `index.js` in the example app -- dont crash when no inbox item id provided.

DDL ts interfaces are:
```
export interface DeepLinkContent {
  title: string | null;
  description: string | null;
}

export interface DeepLink {
  resolution: DeepLinkResolution;
  url: string;
  content: DeepLinkContent | null;
  linkData: Record<string,any> | null;
}

export enum DeepLinkResolution {
  LOOKUP_FAILED = "LOOKUP_FAILED",
  LINK_NOT_FOUND = "LINK_NOT_FOUND",
  LINK_EXPIRED = "LINK_EXPIRED",
  LINK_LIMIT_EXCEEDED = "LINK_LIMIT_EXCEEDED",
  LINK_MATCHED = "LINK_MATCHED",
}
```