### PR TITLE
Bump version to publish package readme

### DIFF
--- a/ExampleApp/package-lock.json
+++ b/ExampleApp/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "../cordova-sdk": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/cordova-sdk/package-lock.json
+++ b/cordova-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optimove-inc/cordova-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@optimove-inc/cordova-sdk",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cordova-plugin-add-swift-support": "2.0.2"

--- a/cordova-sdk/package.json
+++ b/cordova-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@optimove-inc/cordova-sdk",
   "displayName": "Optimove Cordova plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A sample Apache Cordova application that responds to the deviceready event.",
   "scripts": {
     "build": "webpack",

--- a/cordova-sdk/plugin.xml
+++ b/cordova-sdk/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="optimove-cordova-sdk" version="1.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="optimove-cordova-sdk" version="1.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OptimoveSDKPlugin</name>
     <js-module name="OptimoveCore" src="www/OptimoveCore.js"/>
     <js-module name="Optimove" src="www/Optimove.js">

--- a/cordova-sdk/src/android/OptimoveInitProvider.java
+++ b/cordova-sdk/src/android/OptimoveInitProvider.java
@@ -32,7 +32,7 @@ public class OptimoveInitProvider extends ContentProvider {
 
     private static final String ENABLE_DEFERRED_DEEP_LINKING = "optimoveEnableDeferredDeepLinking";
 
-    private static final String SDK_VERSION = "1.0.0";
+    private static final String SDK_VERSION = "1.0.1";
     private static final int RUNTIME_TYPE = 3;
     private static final int SDK_TYPE = 106;
 

--- a/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
+++ b/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
@@ -20,7 +20,7 @@ enum InAppConsentStrategy: String {
     private static var pendingPush: PushNotification? = nil
     private static var pendingDdl: DeepLinkResolution? = nil
 
-    private static let sdkVersion = "1.0.0"
+    private static let sdkVersion = "1.0.1"
     private static let sdkTypeOptimoveCordova = 106
     private static let runtimeTypeCordova = 3
 


### PR DESCRIPTION
### Description of Changes

Npm doesn't allow publishing without version bump

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [ ] `cd cordova-sdk` and `npm run build` to produce minified artifacts
-   [ ] `cd ExampleApp` and `npm run build` to update `index.js`
-   [ ] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Update type declarations in `cordova-sdk/index.d.ts`

Bump versions in:

-   [ ] package.json
-   [ ] plugin.xml
-   [ ] src/ios/OptimoveSDKPlugin.swift
-   [ ] src/android/OptimoveInitProvider.java

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish --access public`

Update wiki:

- [ ] https://github.com/optimove-tech/Optimove-SDK-Cordova/wiki

