### PR TITLE
Allow setting single credentials

### DIFF
--- a/ExampleApp/package-lock.json
+++ b/ExampleApp/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../cordova-sdk": {
       "name": "@optimove-inc/cordova-sdk",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/cordova-sdk/package.json
+++ b/cordova-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@optimove-inc/cordova-sdk",
   "displayName": "Optimove Cordova plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A sample Apache Cordova application that responds to the deviceready event.",
   "scripts": {
     "build": "webpack",

--- a/cordova-sdk/plugin.xml
+++ b/cordova-sdk/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="optimove-cordova-sdk" version="2.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="optimove-cordova-sdk" version="2.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OptimoveSDKPlugin</name>
     <js-module name="OptimoveCore" src="www/OptimoveCore.js"/>
     <js-module name="Optimove" src="www/Optimove.js">

--- a/cordova-sdk/src/android/OptimoveInitProvider.java
+++ b/cordova-sdk/src/android/OptimoveInitProvider.java
@@ -54,7 +54,7 @@ public class OptimoveInitProvider extends ContentProvider {
         OptimoveConfig.Builder configBuilder = new OptimoveConfig.Builder(optimoveCredentials,
                 optimoveMobileCredentials);
 
-        if (optimoveMobileCredentials == null){
+        if (optimoveMobileCredentials == null) {
             Optimove.initialize(app, configBuilder.build());
             return true;
         }

--- a/cordova-sdk/src/android/OptimoveInitProvider.java
+++ b/cordova-sdk/src/android/OptimoveInitProvider.java
@@ -54,6 +54,11 @@ public class OptimoveInitProvider extends ContentProvider {
         OptimoveConfig.Builder configBuilder = new OptimoveConfig.Builder(optimoveCredentials,
                 optimoveMobileCredentials);
 
+        if (optimoveMobileCredentials == null){
+            Optimove.initialize(app, configBuilder.build());
+            return;
+        }
+
         if (IN_APP_AUTO_ENROLL.equals(inAppConsentStrategy)) {
             configBuilder = configBuilder.enableInAppMessaging(OptimoveConfig.InAppConsentStrategy.AUTO_ENROLL);
         } else if (IN_APP_EXPLICIT_BY_USER.equals(inAppConsentStrategy)) {
@@ -73,6 +78,7 @@ public class OptimoveInitProvider extends ContentProvider {
 
         Optimove.getInstance().setPushActionHandler(new PushReceiver.PushActionHandler());
         OptimoveInApp.getInstance().setOnInboxUpdated(new OptimoveSDKPlugin.InboxUpdatedHandler());
+
         return true;
     }
 

--- a/cordova-sdk/src/android/OptimoveInitProvider.java
+++ b/cordova-sdk/src/android/OptimoveInitProvider.java
@@ -32,7 +32,7 @@ public class OptimoveInitProvider extends ContentProvider {
 
     private static final String ENABLE_DEFERRED_DEEP_LINKING = "optimoveEnableDeferredDeepLinking";
 
-    private static final String SDK_VERSION = "2.0.1";
+    private static final String SDK_VERSION = "2.0.2";
     private static final int RUNTIME_TYPE = 3;
     private static final int SDK_TYPE = 106;
 
@@ -56,7 +56,7 @@ public class OptimoveInitProvider extends ContentProvider {
 
         if (optimoveMobileCredentials == null){
             Optimove.initialize(app, configBuilder.build());
-            return;
+            return true;
         }
 
         if (IN_APP_AUTO_ENROLL.equals(inAppConsentStrategy)) {

--- a/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
+++ b/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
@@ -49,6 +49,13 @@ enum InAppConsentStrategy: String {
             return
         };
 
+
+        if (configValues[optimoveMobileCredentialsKey] == nil) {
+            Optimove.initialize(with: builder.build())
+
+            return
+        }
+
         builder.setPushOpenedHandler(pushOpenedHandlerBlock: { notification in
             guard let pluginInstance = OptimoveSDKPlugin.optimovePluginInstance, let _ = OptimoveSDKPlugin.cordovaCommand else {
                 pendingPush = notification

--- a/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
+++ b/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
@@ -20,7 +20,7 @@ enum InAppConsentStrategy: String {
     private static var pendingPush: PushNotification? = nil
     private static var pendingDdl: DeepLinkResolution? = nil
 
-    private static let sdkVersion = "2.0.1"
+    private static let sdkVersion = "2.0.2"
     private static let sdkTypeOptimoveCordova = 106
     private static let runtimeTypeCordova = 3
 


### PR DESCRIPTION
### Description of Changes

We should allow setting only Optimove or Optimobile credentials.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] `cd cordova-sdk` and `npm run build` to produce minified artifacts
-   [x] `cd ExampleApp` and `npm run build` to update `index.js`
-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Update type declarations in `cordova-sdk/index.d.ts`

Bump versions in:

-   [x] package.json
-   [x] plugin.xml
-   [x] src/ios/OptimoveSDKPlugin.swift
-   [x] src/android/OptimoveInitProvider.java

Release:

-   [ ] Squash and merge to main
-   [ ] Delete branch once merged
-   [ ] Create tag from main matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish --access public`

Update wiki:

- [ ] https://github.com/optimove-tech/Optimove-SDK-Cordova/wiki

