### PR TITLE
Bump cordova-android version

### DIFF
--- a/ExampleApp/package-lock.json
+++ b/ExampleApp/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@optimove-inc/cordova-sdk": "file:../cordova-sdk",
-        "cordova-android": "^10.1.2",
+        "cordova-android": "^11.0.0",
         "cordova-ios": "^6.2.0",
         "ts-loader": "^9.3.1",
         "typescript": "^4.8.3",
@@ -397,21 +397,12 @@
       }
     },
     "node_modules/android-versions": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.1.tgz",
-      "integrity": "sha512-5a0YyylAk6pPM2Ezi0vWaPPNbS6tSNRs+micbgk5NpHEN5YW1ez+T94G5orysfwBEBDMHoxm5GNc5ZDUPgRrhw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.2.tgz",
+      "integrity": "sha512-2MT/Y/mR3BLSbR9E3ugwvE/aA4k84XtjG2Iusu4pRKt4FwfpEvIEAHzm7ZBhL3/aTVNdx3PzZ+sAiK+Dbc4r9A==",
       "dev": true,
       "dependencies": {
-        "semver": "^5.7.1"
-      }
-    },
-    "node_modules/android-versions/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
+        "semver": "^7.5.2"
       }
     },
     "node_modules/ansi": {
@@ -635,25 +626,25 @@
       "license": "MIT"
     },
     "node_modules/cordova-android": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.2.tgz",
-      "integrity": "sha512-F28+NvgKO4ZhKFkqctCOh62mhVoNyUuRQh/F/nqp+Sti4ODv2rUa6UeW18khhdYTjlDeihHQsPqxvB7mI6fVYA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-11.0.0.tgz",
+      "integrity": "sha512-ZhvSF5BYY8gmrAu1PtMPdHFsRoom/emT4OtTcecmh3Zj22900y4Golg5whhBPcYcTPC7BU6PG/EmG9BBHcX9tQ==",
       "dev": true,
       "dependencies": {
         "android-versions": "^1.7.0",
         "cordova-common": "^4.0.2",
         "execa": "^5.1.1",
-        "fast-glob": "^3.2.7",
-        "fs-extra": "^10.0.0",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^10.1.0",
         "is-path-inside": "^3.0.3",
         "nopt": "^5.0.0",
         "properties-parser": "^0.3.1",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "untildify": "^4.0.0",
         "which": "^2.0.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/cordova-common": {
@@ -1737,9 +1728,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2588,20 +2580,12 @@
       "requires": {}
     },
     "android-versions": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.1.tgz",
-      "integrity": "sha512-5a0YyylAk6pPM2Ezi0vWaPPNbS6tSNRs+micbgk5NpHEN5YW1ez+T94G5orysfwBEBDMHoxm5GNc5ZDUPgRrhw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.2.tgz",
+      "integrity": "sha512-2MT/Y/mR3BLSbR9E3ugwvE/aA4k84XtjG2Iusu4pRKt4FwfpEvIEAHzm7ZBhL3/aTVNdx3PzZ+sAiK+Dbc4r9A==",
       "dev": true,
       "requires": {
-        "semver": "^5.7.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "^7.5.2"
       }
     },
     "ansi": {
@@ -2727,20 +2711,20 @@
       "dev": true
     },
     "cordova-android": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.2.tgz",
-      "integrity": "sha512-F28+NvgKO4ZhKFkqctCOh62mhVoNyUuRQh/F/nqp+Sti4ODv2rUa6UeW18khhdYTjlDeihHQsPqxvB7mI6fVYA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-11.0.0.tgz",
+      "integrity": "sha512-ZhvSF5BYY8gmrAu1PtMPdHFsRoom/emT4OtTcecmh3Zj22900y4Golg5whhBPcYcTPC7BU6PG/EmG9BBHcX9tQ==",
       "dev": true,
       "requires": {
         "android-versions": "^1.7.0",
         "cordova-common": "^4.0.2",
         "execa": "^5.1.1",
-        "fast-glob": "^3.2.7",
-        "fs-extra": "^10.0.0",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^10.1.0",
         "is-path-inside": "^3.0.3",
         "nopt": "^5.0.0",
         "properties-parser": "^0.3.1",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "untildify": "^4.0.0",
         "which": "^2.0.2"
       }
@@ -3423,7 +3407,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/ExampleApp/package.json
+++ b/ExampleApp/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@optimove-inc/cordova-sdk": "file:../cordova-sdk",
-    "cordova-android": "^10.1.2",
+    "cordova-android": "^11.0.0",
     "cordova-ios": "^6.2.0",
     "ts-loader": "^9.3.1",
     "typescript": "^4.8.3",


### PR DESCRIPTION
### Description of Changes

Update cordova-android version used in the example app. Version 11 supports android sdk 32.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] `cd cordova-sdk` and `npm run build` to produce minified artifacts
-   [x] `cd ExampleApp` and `npm run build` to update `index.js`
-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Update type declarations in `cordova-sdk/index.d.ts`

Bump versions in:

-   [x] package.json
-   [x] plugin.xml
-   [x] src/ios/OptimoveSDKPlugin.swift
-   [x] src/android/OptimoveInitProvider.java

Release:

-   [ ] Squash and merge to main
-   [ ] Delete branch once merged
-   [ ] Create tag from main matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish --access public`

Update wiki:

- [ ] https://github.com/optimove-tech/Optimove-SDK-Cordova/wiki

