### PR TITLE
242195 Fix app state reset on opening push notification

### DIFF
--- a/cordova-sdk/package.json
+++ b/cordova-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@optimove-inc/cordova-sdk",
   "displayName": "Optimove Cordova plugin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A sample Apache Cordova application that responds to the deviceready event.",
   "scripts": {
     "build": "webpack",

--- a/cordova-sdk/plugin.xml
+++ b/cordova-sdk/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="optimove-cordova-sdk" version="2.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="optimove-cordova-sdk" version="2.2.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OptimoveSDKPlugin</name>
     <js-module name="OptimoveCore" src="www/OptimoveCore.js"/>
     <js-module name="Optimove" src="www/Optimove.js">

--- a/cordova-sdk/src/android/OptimoveInitProvider.java
+++ b/cordova-sdk/src/android/OptimoveInitProvider.java
@@ -39,7 +39,7 @@ public class OptimoveInitProvider extends ContentProvider {
     private static final String DELAYED_INITIALIZATION_ENABLE_OPTIMOVE = "delayedInitialization.featureSet.enableOptimove";
     private static final String DELAYED_INITIALIZATION_ENABLE_OPTIMOBILE = "delayedInitialization.featureSet.enableOptimobile";
 
-    private static final String SDK_VERSION = "2.2.1";
+    private static final String SDK_VERSION = "2.2.2";
     private static final int RUNTIME_TYPE = 3;
     private static final int SDK_TYPE = 106;
 

--- a/cordova-sdk/src/android/PushReceiver.java
+++ b/cordova-sdk/src/android/PushReceiver.java
@@ -58,6 +58,21 @@ public class PushReceiver extends PushBroadcastReceiver {
         PushReceiver.handlePushOpen(context, pushMessage, null);
     }
 
+    @Override
+    protected Intent getPushOpenActivityIntent(Context context, PushMessage pushMessage) {
+            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+
+            if (null == launchIntent) {
+                return null;
+            }
+
+            launchIntent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
+            launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+            return launchIntent;
+        }
+
+
     private static void handlePushOpen(Context context, PushMessage pushMessage, String actionId) {
         PushReceiver pr = new PushReceiver();
         Intent launchIntent = pr.getPushOpenActivityIntent(context, pushMessage);
@@ -91,22 +106,6 @@ public class PushReceiver extends PushBroadcastReceiver {
             addDeepLinkExtras(pushMessage, existingIntent);
         }
 
-        if (null != pushMessage.getUrl()) {
-            launchIntent = new Intent(Intent.ACTION_VIEW, pushMessage.getUrl());
-
-            addDeepLinkExtras(pushMessage, launchIntent);
-
-            TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
-            taskStackBuilder.addParentStack(component);
-            taskStackBuilder.addNextIntent(launchIntent);
-            taskStackBuilder.startActivities();
-        } else {
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-
-            addDeepLinkExtras(pushMessage, launchIntent);
-
-            context.startActivity(launchIntent);
-        }
 
         if (null == OptimoveSDKPlugin.jsCallbackContext) {
             OptimoveSDKPlugin.pendingPush = pushMessage;

--- a/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
+++ b/cordova-sdk/src/ios/OptimoveSDKPlugin.swift
@@ -24,7 +24,7 @@ enum InAppConsentStrategy: String {
     private static var pendingPush: PushNotification? = nil
     private static var pendingDdl: DeepLinkResolution? = nil
 
-    private static let sdkVersion = "2.2.1"
+    private static let sdkVersion = "2.2.2"
     private static let sdkTypeOptimoveCordova = 106
     private static let runtimeTypeCordova = 3
 


### PR DESCRIPTION
[242195](https://mobius.visualstudio.com/Backstage/_workitems/edit/242195)

### Description of Changes

have added override to Android Push Receiver getPushOpenActivityIntent method. opverride does not set Activity clear task flag which was impacting cordova and capcitor apps causing an app restart.

Removed redundant code that breaches trampoline restrictions

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] `cd cordova-sdk` and `npm run build` to produce minified artifacts
-   [x] `cd ExampleApp` and `npm run build` to update `index.js`
-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Update type declarations in `cordova-sdk/index.d.ts`

Bump versions in:

-   [x] package.json
-   [x] plugin.xml
-   [x] src/ios/OptimoveSDKPlugin.swift
-   [x] src/android/OptimoveInitProvider.java

Release:

-   [x] Squash and merge to main
-   [x] Delete branch once merged
-   [x] Create tag from main matching chosen version
-   [x] Fill out release notes
-   [x] Run `npm publish --access public`

Update wiki:

- [ ] https://github.com/optimove-tech/Optimove-SDK-Cordova/wiki

